### PR TITLE
phpbb.de version 1.1.12

### DIFF
--- a/rmcgirr83/contactadmin/adm/style/acp_contact.html
+++ b/rmcgirr83/contactadmin/adm/style/acp_contact.html
@@ -119,7 +119,8 @@
 		<dl>
 			<dt><label for="contact_bot_user">{L_CONTACT_BOT_USER}{L_COLON}</label><br>
 			<span>{L_CONTACT_BOT_USER_EXPLAIN}</span></dt>
-			<dd>{CONTACT_BOT_USER}</dd>
+			<dd><input class="text medium" type="text" id="contact_bot_user" name="contact_bot_user" value="{CONTACT_BOT_USER}"></dd>
+			<dd>[ <a href="{U_FIND_USERNAME}" onclick="find_username(this.href); return false;">{L_FIND_USERNAME}</a> ]</dd>
 		</dl>
 		<dl>
 			<dt><label>{L_CONTACT_BOT_POSTER}{L_COLON}</label><br>

--- a/rmcgirr83/contactadmin/composer.json
+++ b/rmcgirr83/contactadmin/composer.json
@@ -3,8 +3,8 @@
     "type": "phpbb-extension",
     "description": "This form allows guests and/or registered users to either send an email to admins or to either send a PM or make a Post in a designated forum. It also overrides the default contact admin link found on the forum.  A port of the phpBB 3.0.x mod “Contact Board Adminnistration”",
     "homepage": "https://github.com/rmcgirr83/contactadmin",
-    "version": "1.1.11",
-    "time": "2018-12-19",
+    "version": "1.1.12",
+    "time": "2020-02-18",
     "keywords": [
         "phpbb",
         "extension",
@@ -27,7 +27,7 @@
     "extra": {
         "display-name": "Contact Admin",
         "soft-require": {
-            "phpbb/phpbb": ">=3.2, <=3.3"
+            "phpbb/phpbb": ">=3.2, <3.4.0@dev"
         },
         "version-check": {
             "host": "www.phpbb.com",

--- a/rmcgirr83/contactadmin/controller/admin_controller.php
+++ b/rmcgirr83/contactadmin/controller/admin_controller.php
@@ -181,7 +181,7 @@ class admin_controller
 			'CONTACT_METHOD'				=> $this->contactadmin->method_select($this->config['contactadmin_method']),
 			'CONTACT_BOT_POSTER'			=> $this->contactadmin->poster_select($this->config['contactadmin_bot_poster']),
 			'CONTACT_BOT_FORUM'				=> $this->contactadmin->forum_select($this->config['contactadmin_forum']),
-			'CONTACT_BOT_USER'				=> $this->contactadmin->bot_user_select($this->config['contactadmin_bot_user']),
+			'CONTACT_BOT_USER'				=> $this->contactadmin->get_user_name($this->config['contactadmin_bot_user']),
 			'CONTACT_USERNAME_CHK'			=> $this->config['contactadmin_username_chk'],
 			'CONTACT_EMAIL_CHK'				=> $this->config['contactadmin_email_chk'],
 
@@ -205,6 +205,7 @@ class admin_controller
 			'S_LINKS_ALLOWED'		=> true,
 
 			'U_ACTION'				=> $this->u_action,
+			'U_FIND_USERNAME'		=> append_sid("{$this->root_path}memberlist.{$this->php_ext}", "mode=searchuser&amp;form=contactadmin&amp;field=contact_bot_user&amp;select_single=true"),
 		));
 		// Assigning custom bbcodes
 		display_custom_bbcodes();
@@ -220,7 +221,7 @@ class admin_controller
 		$this->config->set('contactadmin_founder_only', $this->request->variable('founder_only', 0));
 		$this->config->set('contactadmin_bot_poster', $this->request->variable('contact_bot_poster', 0));
 		$this->config->set('contactadmin_forum', $this->request->variable('forum', 0));
-		$this->config->set('contactadmin_bot_user', $this->request->variable('bot_user', 0));
+		$this->config->set('contactadmin_bot_user', $this->contactadmin->get_user_id($this->request->variable('contact_bot_user', ''), $this->user->data['user_id']));
 		$this->config->set('contactadmin_username_chk', $this->request->variable('username_chk', 0));
 		$this->config->set('contactadmin_email_chk', $this->request->variable('email_chk', 0));
 		$this->config->set('contactadmin_method', $this->request->variable('contact_method', 0));

--- a/rmcgirr83/contactadmin/core/contactadmin.php
+++ b/rmcgirr83/contactadmin/core/contactadmin.php
@@ -469,4 +469,40 @@ class contactadmin
 		}
 		return $dir_array;
 	}
+
+	/*
+	 * Get user_id from user_name (LukeWCS)
+	 */
+	public function get_user_id($user_name, $default_id = 0)
+	{
+		$sql = 'SELECT user_id
+				FROM ' . USERS_TABLE . "
+				WHERE username_clean = '" . $this->db->sql_escape(utf8_clean_string($user_name)) . "'";
+		$result = $this->db->sql_query($sql);
+		$user_id = (int) $this->db->sql_fetchfield('user_id');
+		$this->db->sql_freeresult($result);
+		if ($user_id == 0 && $default_id != 0)
+		{
+			$user_id = $default_id;
+		}
+		return $user_id;
+	}
+
+	/*
+	 * Get user_name from user_id (LukeWCS)
+	 */
+	public function get_user_name($user_id, $default_name = false)
+	{
+		$sql = 'SELECT username
+				FROM ' . USERS_TABLE . "
+				WHERE user_id = " . (int) $user_id;
+		$result = $this->db->sql_query($sql);
+		$user_name = $this->db->sql_fetchfield('username');
+		$this->db->sql_freeresult($result);
+		if (!$user_name && $default_name)
+		{
+			$user_name = $default_name;
+		}
+		return $user_name;
+	}
 }

--- a/rmcgirr83/contactadmin/ext.php
+++ b/rmcgirr83/contactadmin/ext.php
@@ -26,6 +26,6 @@ class ext extends \phpbb\extension\base
 		$config = $this->container->get('config');
 		// only allow install between 3.1.3 for events added and 3.4 due to 3.4 removing upload function from includes/functions_posting per 3.2
 		// phpBB only supports 3.2 and so will I
-		return phpbb_version_compare($config['version'], '3.2', '>=') && phpbb_version_compare($config['version'], '3.3', '<=');
+		return phpbb_version_compare($config['version'], '3.2', '>=') && phpbb_version_compare($config['version'], '3.4', '<');
 	}
 }

--- a/rmcgirr83/contactadmin/language/de/acp_contact.php
+++ b/rmcgirr83/contactadmin/language/de/acp_contact.php
@@ -38,9 +38,9 @@ if (empty($lang) || !is_array($lang))
 //
 
 $lang = array_merge($lang, array(
-	'CONTACT_CONFIG_SAVED'			=> 'Die „Contact Board Administration“-Konfiguration wurde aktualisiert',
-	'CONTACT_ENABLE'				=> 'Aktiviere die „Contact Board Administration“-Extension',
-	'CONTACT_ENABLE_EXPLAIN'		=> 'Aktiviere oder deaktiviere global die Extension',
+	'CONTACT_CONFIG_SAVED'				=> 'Die „Contact Board Administration“-Konfiguration wurde aktualisiert',
+	'CONTACT_ENABLE'					=> 'Aktiviere die „Contact Board Administration“-Extension',
+	'CONTACT_ENABLE_EXPLAIN'			=> 'Aktiviere oder deaktiviere global die Extension',
 	'CONTACT_ACP_CONFIRM'				=> 'Aktiviere den Bestätigungscode',
 	'CONTACT_ACP_CONFIRM_EXPLAIN'		=> 'Wenn du diese Einstellung aktivierst, müssen die Benutzer einen Bestätigungscode eintragen, um eine Nachricht zu senden.<br>Damit werden Spam-Nachrichten verhindert. Beachte, dass diese Einstellung nur für das Kontaktformular gültig ist. Es beeinflusst keine anderen Bestätigungscodes-Einstellung.',
 	'CONTACT_ATTACHMENTS'				=> 'Dateianhänge erlaubt',
@@ -57,24 +57,24 @@ $lang = array_merge($lang, array(
 	'CONTACT_REASONS'					=> 'Kontaktgründe',
 	'CONTACT_REASONS_EXPLAIN'			=> 'Trage Gründe für den Kontakt ein, je Grund eine eigene Zeile.<br>Wenn du diese Funktion nicht verwenden willst, dann lasse dieses Feld leer.',
 	// Bot config options
-	'CONTACT_BOT_FORUM'				=> 'Kontaktbot',
-	'CONTACT_BOT_FORUM_EXPLAIN'		=> 'Wähle das Forum aus, in das der Kontaktbot schreiben soll, sofern die Kontaktart „Forenbeitrag“ ausgewählt wurde.',
-	'CONTACT_BOT_POSTER'			=> 'Kontaktbot-Benutzer als Beitragsersteller',
-	'CONTACT_BOT_POSTER_EXPLAIN'	=> 'Wenn aktiviert, werden PNs und Beiträge durch den Kontaktbot-Benutzer erstellt. Wenn „Weder noch“ ausgewählt wurde, wird der Kontaktbot-Benutzer nicht verwendet. Dann werden Beiträge und PNs basierend auf den Einträgen in das Kontaktformular erstellt.',
-	'CONTACT_BOT_USER'				=> 'Kontaktbot-Benutzer',
-	'CONTACT_BOT_USER_EXPLAIN'		=> 'Wähle den Benutzer aus, unter dessen Account die Nachrichten erstellen werden, sofern die Kontaktart „Private Nachricht” oder „Forenbeitrag” ausgewählt wurde.',
-	'CONTACT_USERNAME_CHK'			=> 'Prüfe Benutzernamen Username',
-	'CONTACT_USERNAME_CHK_EXPLAIN'	=> 'Wenn aktiviert, werden die eingetragenen Benutzernamen mit der Mitgliederliste abgeglichen. Wenn eine Übereinstimmung gefunden wird, bekommt der Benutzer eine Fehlermeldung gezeigt und wird aufgefordert einen anderen Benutzernamen zu wählen.',
-	'CONTACT_EMAIL_CHK'				=> 'Prüfe E-Mail-Adresse',
-	'CONTACT_EMAIL_CHK_EXPLAIN'		=> 'Wenn aktiviert, werden die eingetragenen E-Mail_Adressen mit der Mitgliederliste abgeglichen. Wenn eine Übereinstimmung gefunden wird, bekommt der Benutzer eine Fehlermeldung gezeigt und wird aufgefordert eine andere E-Mail-Adresse zu verwenden.',
+	'CONTACT_BOT_FORUM'					=> 'Kontaktbot',
+	'CONTACT_BOT_FORUM_EXPLAIN'			=> 'Wähle das Forum aus, in das der Kontaktbot schreiben soll, sofern die Kontaktart „Forenbeitrag“ ausgewählt wurde.',
+	'CONTACT_BOT_POSTER'				=> 'Kontaktbot-Benutzer als Beitragsersteller',
+	'CONTACT_BOT_POSTER_EXPLAIN'		=> 'Wenn aktiviert, werden PNs und Beiträge durch den Kontaktbot-Benutzer erstellt. Wenn „Weder noch“ ausgewählt wurde, wird der Kontaktbot-Benutzer nicht verwendet. Dann werden Beiträge und PNs basierend auf den Einträgen in das Kontaktformular erstellt.',
+	'CONTACT_BOT_USER'					=> 'Kontaktbot-Benutzer',
+	'CONTACT_BOT_USER_EXPLAIN'			=> 'Gib den Benutzer ein, unter dessen Account die Nachrichten erstellen werden, sofern die Kontaktart „Private Nachricht” oder „Forenbeitrag” ausgewählt wurde.',
+	'CONTACT_USERNAME_CHK'				=> 'Prüfe Benutzernamen Username',
+	'CONTACT_USERNAME_CHK_EXPLAIN'		=> 'Wenn aktiviert, werden die eingetragenen Benutzernamen mit der Mitgliederliste abgeglichen. Wenn eine Übereinstimmung gefunden wird, bekommt der Benutzer eine Fehlermeldung gezeigt und wird aufgefordert einen anderen Benutzernamen zu wählen.',
+	'CONTACT_EMAIL_CHK'					=> 'Prüfe E-Mail-Adresse',
+	'CONTACT_EMAIL_CHK_EXPLAIN'			=> 'Wenn aktiviert, werden die eingetragenen E-Mail_Adressen mit der Mitgliederliste abgeglichen. Wenn eine Übereinstimmung gefunden wird, bekommt der Benutzer eine Fehlermeldung gezeigt und wird aufgefordert eine andere E-Mail-Adresse zu verwenden.',
 
 	// Contact methods
-	'CONTACT_METHOD_EMAIL'			=> 'E-Mail',
-	'CONTACT_METHOD_PM'				=> 'Private Nachricht',
-	'CONTACT_METHOD_POST'			=> 'Forenbeitrag',
+	'CONTACT_METHOD_EMAIL'				=> 'E-Mail',
+	'CONTACT_METHOD_PM'					=> 'Private Nachricht',
+	'CONTACT_METHOD_POST'				=> 'Forenbeitrag',
 
 	// Contact posters...user bot
-	'CONTACT_POST_NEITHER'			=> 'Weder noch',
-	'CONTACT_POST_GUEST'			=> 'Nur Gäste',
-	'CONTACT_POST_ALL'				=> 'Jeder',
+	'CONTACT_POST_NEITHER'				=> 'Weder noch',
+	'CONTACT_POST_GUEST'				=> 'Nur Gäste',
+	'CONTACT_POST_ALL'					=> 'Jeder',
 ));

--- a/rmcgirr83/contactadmin/language/en/acp_contact.php
+++ b/rmcgirr83/contactadmin/language/en/acp_contact.php
@@ -37,9 +37,9 @@ if (empty($lang) || !is_array($lang))
 //
 
 $lang = array_merge($lang, array(
-	'CONTACT_CONFIG_SAVED'			=> 'Contact Board Administration configuration has been updated',
-	'CONTACT_ENABLE'				=> 'Enable Contact Board Administration Extension',
-	'CONTACT_ENABLE_EXPLAIN'		=> 'Enable or disable the extension globally',
+	'CONTACT_CONFIG_SAVED'				=> 'Contact Board Administration configuration has been updated',
+	'CONTACT_ENABLE'					=> 'Enable Contact Board Administration Extension',
+	'CONTACT_ENABLE_EXPLAIN'			=> 'Enable or disable the extension globally',
 	'CONTACT_ACP_CONFIRM'				=> 'Enable visual confirmation',
 	'CONTACT_ACP_CONFIRM_EXPLAIN'		=> 'If you enable this option, users will have to enter a visual confirmation to send the message.<br>This is to prevent spam messages. Note that this option is for the contact page only.  It does not affect other visual confirmation settings.',
 	'CONTACT_ATTACHMENTS'				=> 'Attachments allowed',
@@ -56,24 +56,24 @@ $lang = array_merge($lang, array(
 	'CONTACT_REASONS'					=> 'Contact reasons',
 	'CONTACT_REASONS_EXPLAIN'			=> 'Enter reasons for contacting, separated by new lines.<br>If you don’t want to use this feature, leave this field empty.',
 	// Bot config options
-	'CONTACT_BOT_FORUM'				=> 'Contact bot forum',
-	'CONTACT_BOT_FORUM_EXPLAIN'		=> 'Select the forum, where the contact bot should post to, if the contact method is set to “Forum post”.',
-	'CONTACT_BOT_POSTER'			=> 'Bot as Poster',
-	'CONTACT_BOT_POSTER_EXPLAIN'	=> 'If set PM’s and posts will seem to come from the contact bot user chosen above based on the settings here. If “Neither” is selected then the bot is not used as the poster.  Posts and PM’s will be posted based on the information entered in the contact form.',
-	'CONTACT_BOT_USER'				=> 'Contact bot user',
-	'CONTACT_BOT_USER_EXPLAIN'		=> 'Select the user that messages will be posted under if the contact method is set to “Private Message” or “Forum Post”.',
-	'CONTACT_USERNAME_CHK'			=> 'Check Username',
-	'CONTACT_USERNAME_CHK_EXPLAIN'	=> 'If set yes, the users name that is entered will be checked against those in the database. If a similar name is found the user will be presented with an error and asked to input a different user name.',
-	'CONTACT_EMAIL_CHK'				=> 'Check Email',
-	'CONTACT_EMAIL_CHK_EXPLAIN'		=> 'If set yes, the users email will be checked against those in the database. If a similar email is found the user will be presented with an error and asked to input a different email address.',
+	'CONTACT_BOT_FORUM'					=> 'Contact bot forum',
+	'CONTACT_BOT_FORUM_EXPLAIN'			=> 'Select the forum, where the contact bot should post to, if the contact method is set to “Forum post”.',
+	'CONTACT_BOT_POSTER'				=> 'Bot as Poster',
+	'CONTACT_BOT_POSTER_EXPLAIN'		=> 'If set PM’s and posts will seem to come from the contact bot user chosen above based on the settings here. If “Neither” is selected then the bot is not used as the poster.  Posts and PM’s will be posted based on the information entered in the contact form.',
+	'CONTACT_BOT_USER'					=> 'Contact bot user',
+	'CONTACT_BOT_USER_EXPLAIN'			=> 'Enter the user that messages will be posted under if the contact method is set to “Private Message” or “Forum Post”.',
+	'CONTACT_USERNAME_CHK'				=> 'Check Username',
+	'CONTACT_USERNAME_CHK_EXPLAIN'		=> 'If set yes, the users name that is entered will be checked against those in the database. If a similar name is found the user will be presented with an error and asked to input a different user name.',
+	'CONTACT_EMAIL_CHK'					=> 'Check Email',
+	'CONTACT_EMAIL_CHK_EXPLAIN'			=> 'If set yes, the users email will be checked against those in the database. If a similar email is found the user will be presented with an error and asked to input a different email address.',
 
 	// Contact methods
-	'CONTACT_METHOD_EMAIL'			=> 'Email',
-	'CONTACT_METHOD_PM'				=> 'Private message',
-	'CONTACT_METHOD_POST'			=> 'Forum post',
+	'CONTACT_METHOD_EMAIL'				=> 'Email',
+	'CONTACT_METHOD_PM'					=> 'Private message',
+	'CONTACT_METHOD_POST'				=> 'Forum post',
 
 	// Contact posters...user bot
-	'CONTACT_POST_NEITHER'			=> 'Neither',
-	'CONTACT_POST_GUEST'			=> 'Guests only',
-	'CONTACT_POST_ALL'				=> 'Everyone',
+	'CONTACT_POST_NEITHER'				=> 'Neither',
+	'CONTACT_POST_GUEST'				=> 'Guests only',
+	'CONTACT_POST_ALL'					=> 'Everyone',
 ));

--- a/rmcgirr83/contactadmin/license.txt
+++ b/rmcgirr83/contactadmin/license.txt
@@ -1,12 +1,12 @@
-		    GNU GENERAL PUBLIC LICENSE
-		       Version 2, June 1991
+GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
 
- Copyright (C) 1989, 1991 Free Software Foundation, Inc.
-                       51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
-			    Preamble
+                            Preamble
 
   The licenses for most software are designed to take away your
 freedom to share and change it.  By contrast, the GNU General Public
@@ -15,7 +15,7 @@ software--to make sure the software is free for all its users.  This
 General Public License applies to most of the Free Software
 Foundation's software and to any other program whose authors commit to
 using it.  (Some other Free Software Foundation software is covered by
-the GNU Library General Public License instead.)  You can apply it to
+the GNU Lesser General Public License instead.)  You can apply it to
 your programs, too.
 
   When we speak of free software, we are referring to freedom, not
@@ -55,8 +55,8 @@ patent must be licensed for everyone's free use or not licensed at all.
 
   The precise terms and conditions for copying, distribution and
 modification follow.
-
-		    GNU GENERAL PUBLIC LICENSE
+
+                    GNU GENERAL PUBLIC LICENSE
    TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
 
   0. This License applies to any program or other work which contains
@@ -110,7 +110,7 @@ above, provided that you also meet all of these conditions:
     License.  (Exception: if the Program itself is interactive but
     does not normally print such an announcement, your work based on
     the Program is not required to print an announcement.)
-
+
 These requirements apply to the modified work as a whole.  If
 identifiable sections of that work are not derived from the Program,
 and can be reasonably considered independent and separate works in
@@ -168,7 +168,7 @@ access to copy from a designated place, then offering equivalent
 access to copy the source code from the same place counts as
 distribution of the source code, even though third parties are not
 compelled to copy the source along with the object code.
-
+
   4. You may not copy, modify, sublicense, or distribute the Program
 except as expressly provided under this License.  Any attempt
 otherwise to copy, modify, sublicense or distribute the Program is
@@ -225,7 +225,7 @@ impose that choice.
 
 This section is intended to make thoroughly clear what is believed to
 be a consequence of the rest of this License.
-
+
   8. If the distribution and/or use of the Program is restricted in
 certain countries either by patents or by copyrighted interfaces, the
 original copyright holder who places the Program under this License
@@ -255,7 +255,7 @@ make exceptions for this.  Our decision will be guided by the two goals
 of preserving the free status of all derivatives of our free software and
 of promoting the sharing and reuse of software generally.
 
-			    NO WARRANTY
+                            NO WARRANTY
 
   11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
 FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
@@ -277,64 +277,4 @@ YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
 PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGES.
 
-		     END OF TERMS AND CONDITIONS
-
-	    How to Apply These Terms to Your New Programs
-
-  If you develop a new program, and you want it to be of the greatest
-possible use to the public, the best way to achieve this is to make it
-free software which everyone can redistribute and change under these terms.
-
-  To do so, attach the following notices to the program.  It is safest
-to attach them to the start of each source file to most effectively
-convey the exclusion of warranty; and each file should have at least
-the "copyright" line and a pointer to where the full notice is found.
-
-    <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) <year>  <name of author>
-
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation; either version 2 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
-
-
-Also add information on how to contact you by electronic and paper mail.
-
-If the program is interactive, make it output a short notice like this
-when it starts in an interactive mode:
-
-    Gnomovision version 69, Copyright (C) year name of author
-    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
-    This is free software, and you are welcome to redistribute it
-    under certain conditions; type `show c' for details.
-
-The hypothetical commands `show w' and `show c' should show the appropriate
-parts of the General Public License.  Of course, the commands you use may
-be called something other than `show w' and `show c'; they could even be
-mouse-clicks or menu items--whatever suits your program.
-
-You should also get your employer (if you work as a programmer) or your
-school, if any, to sign a "copyright disclaimer" for the program, if
-necessary.  Here is a sample; alter the names:
-
-  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
-  `Gnomovision' (which makes passes at compilers) written by James Hacker.
-
-  <signature of Ty Coon>, 1 April 1989
-  Ty Coon, President of Vice
-
-This General Public License does not permit incorporating your program into
-proprietary programs.  If your program is a subroutine library, you may
-consider it more useful to permit linking proprietary applications with the
-library.  If this is what you want to do, use the GNU Library General
-Public License instead of this License.
+                     END OF TERMS AND CONDITIONS

--- a/rmcgirr83/contactadmin/migrations/version_1_1_12.php
+++ b/rmcgirr83/contactadmin/migrations/version_1_1_12.php
@@ -1,0 +1,31 @@
+<?php
+/**
+*
+* Contact admin extension for the phpBB Forum Software package.
+*
+* @copyright 2016 Rich McGirr (RMcGirr83)
+* @license GNU General Public License, version 2 (GPL-2.0)
+*
+*/
+
+namespace rmcgirr83\contactadmin\migrations;
+
+/**
+* Primary migration
+*/
+
+class version_1_1_12 extends \phpbb\db\migration\migration
+{
+	static public function depends_on()
+	{
+		return array('\rmcgirr83\contactadmin\migrations\version_100');
+	}
+
+	public function update_data()
+	{
+		return array(
+			array('config.remove', array('contactadmin_mail_chk')),
+			array('config.add', array('contactadmin_email_chk', false)),
+		);
+	}
+}


### PR DESCRIPTION
Related to issue https://github.com/Crizz0/contactadmin/issues/1

* Instead of the dropdown menu for selecting the contact bot user, there is now an input field.
* In addition, the contact bot user can also be selected via phpBB's user search, with all the advantages it offers.
* When saving, the ID is automatically determined from the user name because CA works internally with the ID.
* If an invalid user name is entered or the input field is deleted, the user ID of the administrator who saved the settings is automatically used when saving.
* 2 new functions built in to be able to determine the ID from the user name and the user name from the ID.
* License file updated. Source: "phpBB Skeleton Extension 1.1.4"
* Fix: A typo in the migration `version_100` created a wrong config variable in the DB that was not used and at the same time the correct variable was missing directly after the installation. This variable was only created once the settings were saved. In addition, the correct variable was not removed from the DB during the uninstallation. Both problems fixed with the migration `version_1_1_12`.
* Fix: An error in the version comparison in `ext.php` prevented an installation with phpBB 3.3.